### PR TITLE
F64

### DIFF
--- a/kind-lang.cabal
+++ b/kind-lang.cabal
@@ -33,6 +33,7 @@ library
                     , directory==1.3.8.3
                     , hs-highlight == 1.0.3
                     , filepath==1.5.2.0
+                    , mtl==2.3.1
     hs-source-dirs:   src
     default-language: GHC2024
 
@@ -45,5 +46,6 @@ executable kind
                     , directory==1.3.8.3
                     , hs-highlight == 1.0.3
                     , filepath==1.5.2.0
+                    , mtl==2.3.1
     hs-source-dirs:   app
     default-language: GHC2024

--- a/src/Kind/API.hs
+++ b/src/Kind/API.hs
@@ -179,57 +179,6 @@ apiPrintWarn term (State _ fill _ _) = do
   else
     return ()
 
--- Gets dependencies of a term
-getDeps :: Term -> [String]
-getDeps term = case term of
-  Ref nam       -> [nam]
-  All _ inp out -> getDeps inp ++ getDeps (out Set)
-  Lam _ bod     -> getDeps (bod Set)
-  App fun arg   -> getDeps fun ++ getDeps arg
-  Ann _ val typ -> getDeps val ++ getDeps typ
-  Slf _ typ bod -> getDeps typ ++ getDeps (bod Set)
-  Ins val       -> getDeps val
-  Dat scp cts t -> concatMap getDeps scp ++ concatMap getDepsCtr cts ++ getDeps t
-  Con _ arg     -> concatMap (getDeps . snd) arg
-  Mat cse       -> concatMap (getDeps . snd) cse
-  Let _ val bod -> getDeps val ++ getDeps (bod Set)
-  Use _ val bod -> getDeps val ++ getDeps (bod Set)
-  Op2 _ fst snd -> getDeps fst ++ getDeps snd
-  Swi zer suc   -> getDeps zer ++ getDeps suc
-  Src _ val     -> getDeps val
-  Hol _ args    -> concatMap getDeps args
-  Met _ args    -> concatMap getDeps args
-  Log msg nxt   -> getDeps msg ++ getDeps nxt
-  Var _ _       -> []
-  Set           -> []
-  U32           -> []
-  F64           -> []
-  Num _         -> []
-  FNum _        -> []
-  Txt _         -> []
-  Lst elems     -> concatMap getDeps elems
-  Nat _         -> []
-
-
--- Gets dependencies of a constructor
-getDepsCtr :: Ctr -> [String]
-getDepsCtr (Ctr _ tele) = getDepsTele tele
-
--- Gets dependencies of a telescope
-getDepsTele :: Tele -> [String]
-getDepsTele (TRet term) = getDeps term
-getDepsTele (TExt _ typ bod) = getDeps typ ++ getDepsTele (bod Set)
-
--- Gets all dependencies (direct and indirect) of a term
-getAllDeps :: Book -> String -> S.Set String
-getAllDeps book name = go S.empty [name] where
-  go visited [] = visited
-  go visited (x:xs)
-    | S.member x visited = go visited xs
-    | otherwise = case M.lookup x book of
-        Just term -> go (S.insert x visited) (getDeps term ++ xs)
-        Nothing   -> go (S.insert x visited) xs
-
 -- Stringification of results
 infoShow :: Book -> Fill -> Info -> IO String
 infoShow book fill info = case info of

--- a/src/Kind/API.hs
+++ b/src/Kind/API.hs
@@ -179,6 +179,57 @@ apiPrintWarn term (State _ fill _ _) = do
   else
     return ()
 
+-- Gets dependencies of a term
+getDeps :: Term -> [String]
+getDeps term = case term of
+  Ref nam       -> [nam]
+  All _ inp out -> getDeps inp ++ getDeps (out Set)
+  Lam _ bod     -> getDeps (bod Set)
+  App fun arg   -> getDeps fun ++ getDeps arg
+  Ann _ val typ -> getDeps val ++ getDeps typ
+  Slf _ typ bod -> getDeps typ ++ getDeps (bod Set)
+  Ins val       -> getDeps val
+  Dat scp cts t -> concatMap getDeps scp ++ concatMap getDepsCtr cts ++ getDeps t
+  Con _ arg     -> concatMap (getDeps . snd) arg
+  Mat cse       -> concatMap (getDeps . snd) cse
+  Let _ val bod -> getDeps val ++ getDeps (bod Set)
+  Use _ val bod -> getDeps val ++ getDeps (bod Set)
+  Op2 _ fst snd -> getDeps fst ++ getDeps snd
+  Swi zer suc   -> getDeps zer ++ getDeps suc
+  Src _ val     -> getDeps val
+  Hol _ args    -> concatMap getDeps args
+  Met _ args    -> concatMap getDeps args
+  Log msg nxt   -> getDeps msg ++ getDeps nxt
+  Var _ _       -> []
+  Set           -> []
+  U32           -> []
+  F64           -> []
+  Num _         -> []
+  FNum _        -> []
+  Txt _         -> []
+  Lst elems     -> concatMap getDeps elems
+  Nat _         -> []
+
+
+-- Gets dependencies of a constructor
+getDepsCtr :: Ctr -> [String]
+getDepsCtr (Ctr _ tele) = getDepsTele tele
+
+-- Gets dependencies of a telescope
+getDepsTele :: Tele -> [String]
+getDepsTele (TRet term) = getDeps term
+getDepsTele (TExt _ typ bod) = getDeps typ ++ getDepsTele (bod Set)
+
+-- Gets all dependencies (direct and indirect) of a term
+getAllDeps :: Book -> String -> S.Set String
+getAllDeps book name = go S.empty [name] where
+  go visited [] = visited
+  go visited (x:xs)
+    | S.member x visited = go visited xs
+    | otherwise = case M.lookup x book of
+        Just term -> go (S.insert x visited) (getDeps term ++ xs)
+        Nothing   -> go (S.insert x visited) xs
+
 -- Stringification of results
 infoShow :: Book -> Fill -> Info -> IO String
 infoShow book fill info = case info of

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -70,14 +70,14 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
   go src Set dep = do
     return Set
 
-  go src U32 dep = do
+  go src U64 dep = do
     return Set
 
   go src F64 dep = do
     return Set
 
   go src (Num num) dep = do
-    return U32
+    return U64
 
   go src (Flt num) dep = do
     return F64
@@ -87,18 +87,19 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
     sndType <- infer src snd dep
 
     case (fstType, sndType) of
-      (U32 , U32) -> do
-        return U32
+      (U64 , U64) -> do
+        return U64
       (F64 , F64) -> do
         return F64
       (F64 , _)   -> do
         envLog (Error src (Ref "F64") sndType (Op2 opr fst snd) dep)
         envFail
-      (U32 , _)   -> do
-        envLog (Error src (Ref "U32") sndType (Op2 opr fst snd) dep)
+      (U64 , _)   -> do
+        envLog (Error src (Ref "U64") sndType (Op2 opr fst snd) dep)
         envFail
       (_ , _)     -> do
-        envLog (Error src (Ref "U32 / F64") (Ref ((termShower True fstType dep) ++ " , " ++ (termShower True sndType dep))) (Op2 opr fst snd) dep)
+        envLog (Error src (Ref "U64 / F64") fstType (Op2 opr fst snd) dep)
+        envLog (Error src (Ref "U64 / F64") sndType (Op2 opr fst snd) dep)
         envFail
 
   go src (Swi zer suc) dep = do
@@ -305,14 +306,14 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
     case reduce book fill 2 typx of
       (All typ_nam typ_inp typ_bod) -> do
         case reduce book fill 2 typ_inp of
-          U32 -> do
+          U64 -> do
             -- Check zero case
-            let zerAnn = Ann False (Num 0) U32
+            let zerAnn = Ann False (Num 0) U64
             check src zer (typ_bod zerAnn) dep
             -- Check successor case
             let n = Var "n" dep
-            let sucAnn = Ann False n U32
-            let sucTyp = All "n" U32 (\x -> typ_bod (Op2 ADD (Num 1) x))
+            let sucAnn = Ann False n U64
+            let sucTyp = All "n" U64 (\x -> typ_bod (Op2 ADD (Num 1) x))
             check src suc sucTyp dep
           _ -> do
             infer src (Swi zer suc) dep

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -84,7 +84,7 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
   go src (Num num) dep = do
     return U32
 
-  go src (FNum num) dep = do
+  go src (Flt num) dep = do
     return F64
 
   go src (Op2 opr fst snd) dep = do

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -97,10 +97,10 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
       (F64 , F64) -> do
         return F64
       (F64 , _)   -> do
-        envLog (Error src (Ref "F64") (Ref (termShower False sndType dep)) (Op2 opr fst snd) dep)
+        envLog (Error src (Ref "F64") sndType (Op2 opr fst snd) dep)
         envFail
       (U32 , _)   -> do
-        envLog (Error src (Ref "U32") (Ref (termShower False sndType dep)) (Op2 opr fst snd) dep)
+        envLog (Error src (Ref "U32") sndType (Op2 opr fst snd) dep)
         envFail
       (_ , _)     -> do
         envLog (Error src (Ref "U32 / F64") (Ref ((termShower True fstType dep) ++ " , " ++ (termShower True sndType dep))) (Op2 opr fst snd) dep)

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -242,23 +242,12 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
       (All typ_nam typ_inp typ_bod) -> do
         case reduce book fill 2 typ_inp of
           (Dat adt_scp adt_cts adt_typ) -> do
-            let adt_cts_map = M.fromList (map (\ (Ctr cnm tele) -> (cnm, tele)) adt_cts)
-            -- Check if all cases are present
-            let hasDefaultCase = any (\(cnm, _) -> cnm == "_") cse
-            unless hasDefaultCase $ do
-              let presentCases = M.fromList cse
-              forM_ adt_cts $ \ (Ctr cnm _) -> do
-                unless (M.member cnm presentCases) $ do
-                  envLog (Error src (Hol ("missing_case:" ++ cnm) []) (Hol "incomplete_match" []) (Mat cse) dep)
-                  envFail
-            -- If there is a default case, check that it is well-typed
-            when hasDefaultCase $ do
-              let defaultCase = snd $ head $ filter (\(cnm, _) -> cnm == "_") cse
-              check Nothing defaultCase (All "" typ_inp typ_bod) dep
-            -- Check if all concrete cases are well-typed
-            forM_ cse $ \ (cnm, cbod) -> do
-              when (cnm /= "_") $ case M.lookup cnm adt_cts_map of
-                Just tele -> do
+            -- Check every expected case of the match
+            -- Skips redundant cases
+            let presentCases = M.fromList $ reverse cse
+            forM_ adt_cts $ \ (Ctr cnm tele) -> do
+              case M.lookup cnm presentCases of
+                Just cbod -> do
                   let a_r = teleToTerm tele dep
                   let eqs = extractEqualities (reduce book fill 2 typ_inp) (reduce book fill 2 (snd a_r)) dep
                   let rt0 = teleToType tele (typ_bod (Ann False (Con cnm (fst a_r)) typ_inp)) dep
@@ -267,6 +256,18 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
                     unreachable Nothing cbod dep
                   else
                     check Nothing cbod rt1 dep
+                Nothing -> case M.lookup "_" presentCases of
+                  Just defaultCase -> do
+                    check Nothing defaultCase (All "" typ_inp typ_bod) dep
+                  Nothing -> do
+                    envLog (Error src (Hol ("missing_case:" ++ cnm) []) (Hol "incomplete_match" []) (Mat cse) dep)
+                    envFail
+
+            -- Check if all cases refer to an expected constructor
+            let adt_cts_map = M.fromList (map (\ (Ctr cnm tele) -> (cnm, tele)) adt_cts)
+            forM_ cse $ \ (cnm, cbod) -> do
+              when (cnm /= "_") $ case M.lookup cnm adt_cts_map of
+                Just _ -> return ()
                 Nothing -> do
                   envLog (Error src (Hol ("constructor_not_found:"++cnm) []) (Hol "unknown_type" []) (Mat cse) dep)
                   envFail

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -78,8 +78,14 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
   go src U32 dep = do
     return Set
 
+  go src F64 dep = do
+    return Set
+
   go src (Num num) dep = do
     return U32
+
+  go src (FNum num) dep = do
+    return F64
 
   go src (Op2 opr fst snd) dep = do
     envSusp (Check Nothing fst U32 dep)

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -70,37 +70,16 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
   go src Set dep = do
     return Set
 
-  go src U64 dep = do
-    return Set
-
-  go src F64 dep = do
+  go src U32 dep = do
     return Set
 
   go src (Num num) dep = do
-    return U64
-
-  go src (Flt num) dep = do
-    return F64
+    return U32
 
   go src (Op2 opr fst snd) dep = do
-    fstType <- infer src fst dep
-    sndType <- infer src snd dep
-
-    case (fstType, sndType) of
-      (U64 , U64) -> do
-        return U64
-      (F64 , F64) -> do
-        return F64
-      (F64 , _)   -> do
-        envLog (Error src (Ref "F64") sndType (Op2 opr fst snd) dep)
-        envFail
-      (U64 , _)   -> do
-        envLog (Error src (Ref "U64") sndType (Op2 opr fst snd) dep)
-        envFail
-      (_ , _)     -> do
-        envLog (Error src (Ref "U64 / F64") fstType (Op2 opr fst snd) dep)
-        envLog (Error src (Ref "U64 / F64") sndType (Op2 opr fst snd) dep)
-        envFail
+    envSusp (Check Nothing fst U32 dep)
+    envSusp (Check Nothing snd U32 dep)
+    return U32
 
   go src (Swi zer suc) dep = do
     envLog (Error src (Ref "annotation") (Ref "switch") (Swi zer suc) dep)
@@ -306,14 +285,14 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
     case reduce book fill 2 typx of
       (All typ_nam typ_inp typ_bod) -> do
         case reduce book fill 2 typ_inp of
-          U64 -> do
+          U32 -> do
             -- Check zero case
-            let zerAnn = Ann False (Num 0) U64
+            let zerAnn = Ann False (Num 0) U32
             check src zer (typ_bod zerAnn) dep
             -- Check successor case
             let n = Var "n" dep
-            let sucAnn = Ann False n U64
-            let sucTyp = All "n" U64 (\x -> typ_bod (Op2 ADD (Num 1) x))
+            let sucAnn = Ann False n U32
+            let sucTyp = All "n" U32 (\x -> typ_bod (Op2 ADD (Num 1) x))
             check src suc sucTyp dep
           _ -> do
             infer src (Swi zer suc) dep

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -59,11 +59,6 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
         envLog (Error src (Ref "Self") vtyp (Ins val) dep)
         envFail
 
-  go src (Dat scp cts typ) dep = do
-    forM_ cts $ \ (Ctr _ tele) -> do
-      checkTele Nothing tele Set dep
-    return Set
-
   go src (Ref nam) dep = do
     book <- envGetBook
     case M.lookup nam book of
@@ -116,6 +111,18 @@ infer src term dep = debug ("infer: " ++ termShower False term dep) $ go src ter
 
   go src (Use nam val bod) dep = do
     infer src (bod val) dep
+
+  go src (Dat scp cts typ) dep = do
+    forM_ cts $ \ (Ctr _ tele) -> do
+      checkTele Nothing tele Set dep
+    return Set
+    where
+      checkTele :: Maybe Cod -> Tele -> Term -> Int -> Env ()
+      checkTele src tele typ dep = case tele of
+        TRet term -> check src term typ dep
+        TExt nam inp bod -> do
+          check src inp Set dep
+          checkTele src (bod (Ann False (Var nam dep) inp)) typ (dep + 1)
 
   go src (Con nam arg) dep = do
     envLog (Error src (Ref "annotation") (Ref "constructor") (Con nam arg) dep)
@@ -212,6 +219,21 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
       _ -> do
         infer src (Con nam arg) dep
         return ()
+    where
+      checkConAgainstTele :: Maybe Cod -> [(Maybe String, Term)] -> Tele -> Int -> Env Term
+      checkConAgainstTele src [] (TRet ret) _ = return ret
+      checkConAgainstTele src ((maybeField, arg):args) (TExt nam inp bod) dep = do
+        case maybeField of
+          Just field -> if field /= nam
+            then do
+              envLog (Error src (Hol ("expected:" ++ nam) []) (Hol ("detected:" ++ field) []) (Hol "field_mismatch" []) dep)
+              envFail
+            else check src arg inp dep
+          Nothing -> check src arg inp dep
+        checkConAgainstTele src args (bod arg) (dep + 1)
+      checkConAgainstTele src _ _ dep = do
+        envLog (Error src (Hol "constructor_arity_mismatch" []) (Hol "unknown_type" []) (Hol "constructor" []) dep)
+        envFail
 
   go src (Mat cse) typx dep = do
     book <- envGetBook
@@ -254,6 +276,27 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
       _ -> do
         infer src (Mat cse) dep
         return ()
+    where
+      unreachable :: Maybe Cod -> Term -> Int -> Env ()
+      unreachable src (Lam nam bod)     dep = unreachable src (bod (Con "void" [])) (dep+1)
+      unreachable src (Hol nam ctx)     dep = envLog (Found nam (Hol "unreachable" []) ctx dep) >> return ()
+      unreachable src (Let nam val bod) dep = unreachable src (bod (Con "void" [])) (dep+1)
+      unreachable src (Use nam val bod) dep = unreachable src (bod (Con "void" [])) (dep+1)
+      unreachable _   (Src src val)     dep = unreachable (Just src) val dep
+      unreachable src term              dep = return ()
+
+      teleToType :: Tele -> Term -> Int -> Term
+      teleToType (TRet _)           ret _   = ret
+      teleToType (TExt nam inp bod) ret dep = All nam inp (\x -> teleToType (bod x) ret (dep + 1))
+
+      teleToTerm :: Tele -> Int -> ([(Maybe String, Term)], Term)
+      teleToTerm tele dep = go tele [] dep where
+        go (TRet ret)         args _   = (reverse args, ret)
+        go (TExt nam inp bod) args dep = go (bod (Var nam dep)) ((Just nam, Var nam dep) : args) (dep + 1)
+
+      extractEqualities :: Term -> Term -> Int -> [(Term, Term)]
+      extractEqualities (Dat as _ at) (Dat bs _ bt) dep = zip as bs where
+      extractEqualities a             b             dep = trace ("Unexpected terms: " ++ termShower True a dep ++ " and " ++ termShower True b dep) []
 
   go src (Swi zer suc) typx dep = do
     book <- envGetBook
@@ -334,49 +377,6 @@ check src val typ dep = debug ("check: " ++ termShower False val dep ++ "\n    :
     else do
       envLog (Error src expected detected term dep)
       envFail
-
-unreachable :: Maybe Cod -> Term -> Int -> Env ()
-unreachable src (Lam nam bod)     dep = unreachable src (bod (Con "void" [])) (dep+1)
-unreachable src (Hol nam ctx)     dep = envLog (Found nam (Hol "unreachable" []) ctx dep) >> return ()
-unreachable src (Let nam val bod) dep = unreachable src (bod (Con "void" [])) (dep+1)
-unreachable src (Use nam val bod) dep = unreachable src (bod (Con "void" [])) (dep+1)
-unreachable _   (Src src val)     dep = unreachable (Just src) val dep
-unreachable src term              dep = return ()
-
-checkTele :: Maybe Cod -> Tele -> Term -> Int -> Env ()
-checkTele src tele typ dep = case tele of
-  TRet term -> check src term typ dep
-  TExt nam inp bod -> do
-    check src inp Set dep
-    checkTele src (bod (Ann False (Var nam dep) inp)) typ (dep + 1)
-
-checkConAgainstTele :: Maybe Cod -> [(Maybe String, Term)] -> Tele -> Int -> Env Term
-checkConAgainstTele src [] (TRet ret) _ = return ret
-checkConAgainstTele src ((maybeField, arg):args) (TExt nam inp bod) dep = do
-  case maybeField of
-    Just field -> if field /= nam
-      then do
-        envLog (Error src (Hol ("expected:" ++ nam) []) (Hol ("detected:" ++ field) []) (Hol "field_mismatch" []) dep)
-        envFail
-      else check src arg inp dep
-    Nothing -> check src arg inp dep
-  checkConAgainstTele src args (bod arg) (dep + 1)
-checkConAgainstTele src _ _ dep = do
-  envLog (Error src (Hol "constructor_arity_mismatch" []) (Hol "unknown_type" []) (Hol "constructor" []) dep)
-  envFail
-
-teleToType :: Tele -> Term -> Int -> Term
-teleToType (TRet _)           ret _   = ret
-teleToType (TExt nam inp bod) ret dep = All nam inp (\x -> teleToType (bod x) ret (dep + 1))
-
-teleToTerm :: Tele -> Int -> ([(Maybe String, Term)], Term)
-teleToTerm tele dep = go tele [] dep where
-  go (TRet ret)         args _   = (reverse args, ret)
-  go (TExt nam inp bod) args dep = go (bod (Var nam dep)) ((Just nam, Var nam dep) : args) (dep + 1)
-
-extractEqualities :: Term -> Term -> Int -> [(Term, Term)]
-extractEqualities (Dat as _ at) (Dat bs _ bt) dep = zip as bs where
-extractEqualities a             b             dep = trace ("Unexpected terms: " ++ termShower True a dep ++ " and " ++ termShower True b dep) []
 
 doCheck :: Term -> Env ()
 doCheck (Ann _ val typ) = do

--- a/src/Kind/CompileJS.hs
+++ b/src/Kind/CompileJS.hs
@@ -43,7 +43,7 @@ termToJS term dep = case term of
     -- let cse' = map (\(cnam, cbod) -> concat ["case \"", nameToJS cnam, "\": return APPLY(", termToJS cbod dep, ", x);"]) cse
     -- in concat ["(x => { switch (x.$) { ", unwords cse', " } })"]
     -- TODO: refactor this so that a case named "_" is compiled to a "default" in JS (instead of 'case "_"'):
-    let cse' = map (\(cnam, cbod) ->
+    let cse' = map (\ (cnam, cbod) ->
                 if cnam == "_"
                   then concat ["default: return (", termToJS cbod dep, ")(x);"]
                   else concat ["case \"", cnam, "\": return APPLY(", termToJS cbod dep, ", x);"]) cse

--- a/src/Kind/CompileJS.hs
+++ b/src/Kind/CompileJS.hs
@@ -67,7 +67,7 @@ termToJS var term dep = case term of
     termToJS var (bod val) dep
   Set ->
     ret var "null"
-  U32 ->
+  U64 ->
     ret var "null"
   Num val ->
     ret var $ show val

--- a/src/Kind/Equal.hs
+++ b/src/Kind/Equal.hs
@@ -112,7 +112,11 @@ identical a b dep = do
     return True
   go U32 U32 dep =
     return True
+  go F64 F64 dep =
+    return True
   go (Num aVal) (Num bVal) dep =
+    return (aVal == bVal)
+  go (FNum aVal) (FNum bVal) dep =
     return (aVal == bVal)
   go (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep = do
     iFst <- identical aFst bFst dep
@@ -401,7 +405,11 @@ same a (Hol bNam bCtx) dep =
   True
 same U32 U32 dep =
   True
+same F64 F64 dep =
+  True
 same (Num aVal) (Num bVal) dep =
+  aVal == bVal
+same (FNum aVal) (FNum bVal) dep =
   aVal == bVal
 same (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep =
   same aFst bFst dep && same aSnd bSnd dep
@@ -465,7 +473,9 @@ subst lvl neo term = go term where
   go (Hol nam ctx)     = Hol nam (map go ctx)
   go Set               = Set
   go U32               = U32
+  go F64               = F64
   go (Num n)           = Num n
+  go (FNum n)          = FNum n
   go (Op2 opr fst snd) = Op2 opr (go fst) (go snd)
   go (Txt txt)         = Txt txt
   go (Lst lst)         = Lst (map go lst)
@@ -498,7 +508,9 @@ replace old neo term dep = if same old term dep then neo else go term where
   go (Hol nam ctx)      = Hol nam (map (\x -> replace old neo x (dep+1)) ctx)
   go Set                = Set
   go U32                = U32
+  go F64                = F64
   go (Num n)            = Num n
+  go (FNum n)           = FNum n
   go (Op2 opr fst snd)  = Op2 opr (replace old neo fst dep) (replace old neo snd dep)
   go (Txt txt)          = Txt txt
   go (Lst lst)          = Lst (map (\x -> replace old neo x dep) lst)

--- a/src/Kind/Equal.hs
+++ b/src/Kind/Equal.hs
@@ -110,7 +110,7 @@ identical a b dep = do
     return True
   go a (Hol bNam bCtx) dep =
     return True
-  go U32 U32 dep =
+  go U64 U64 dep =
     return True
   go F64 F64 dep =
     return True
@@ -403,7 +403,7 @@ same (Hol aNam aCtx) b dep =
   True
 same a (Hol bNam bCtx) dep =
   True
-same U32 U32 dep =
+same U64 U64 dep =
   True
 same F64 F64 dep =
   True
@@ -472,10 +472,10 @@ subst lvl neo term = go term where
   go (Log msg nxt)     = Log (go msg) (go nxt)
   go (Hol nam ctx)     = Hol nam (map go ctx)
   go Set               = Set
-  go U32               = U32
+  go U64               = U64
   go F64               = F64
   go (Num n)           = Num n
-  go (Flt n)          = Flt n
+  go (Flt n)           = Flt n
   go (Op2 opr fst snd) = Op2 opr (go fst) (go snd)
   go (Txt txt)         = Txt txt
   go (Lst lst)         = Lst (map go lst)
@@ -507,10 +507,10 @@ replace old neo term dep = if same old term dep then neo else go term where
   go (Log msg nxt)      = Log (replace old neo msg dep) (replace old neo nxt dep)
   go (Hol nam ctx)      = Hol nam (map (\x -> replace old neo x (dep+1)) ctx)
   go Set                = Set
-  go U32                = U32
+  go U64                = U64
   go F64                = F64
   go (Num n)            = Num n
-  go (Flt n)           = Flt n
+  go (Flt n)            = Flt n
   go (Op2 opr fst snd)  = Op2 opr (replace old neo fst dep) (replace old neo snd dep)
   go (Txt txt)          = Txt txt
   go (Lst lst)          = Lst (map (\x -> replace old neo x dep) lst)

--- a/src/Kind/Equal.hs
+++ b/src/Kind/Equal.hs
@@ -116,7 +116,7 @@ identical a b dep = do
     return True
   go (Num aVal) (Num bVal) dep =
     return (aVal == bVal)
-  go (FNum aVal) (FNum bVal) dep =
+  go (Flt aVal) (Flt bVal) dep =
     return (aVal == bVal)
   go (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep = do
     iFst <- identical aFst bFst dep
@@ -409,7 +409,7 @@ same F64 F64 dep =
   True
 same (Num aVal) (Num bVal) dep =
   aVal == bVal
-same (FNum aVal) (FNum bVal) dep =
+same (Flt aVal) (Flt bVal) dep =
   aVal == bVal
 same (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep =
   same aFst bFst dep && same aSnd bSnd dep
@@ -475,7 +475,7 @@ subst lvl neo term = go term where
   go U32               = U32
   go F64               = F64
   go (Num n)           = Num n
-  go (FNum n)          = FNum n
+  go (Flt n)          = Flt n
   go (Op2 opr fst snd) = Op2 opr (go fst) (go snd)
   go (Txt txt)         = Txt txt
   go (Lst lst)         = Lst (map go lst)
@@ -510,7 +510,7 @@ replace old neo term dep = if same old term dep then neo else go term where
   go U32                = U32
   go F64                = F64
   go (Num n)            = Num n
-  go (FNum n)           = FNum n
+  go (Flt n)           = Flt n
   go (Op2 opr fst snd)  = Op2 opr (replace old neo fst dep) (replace old neo snd dep)
   go (Txt txt)          = Txt txt
   go (Lst lst)          = Lst (map (\x -> replace old neo x dep) lst)

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -368,7 +368,7 @@ parseRef = withSrc $ do
   (_, _, uses) <- P.getState
   let name' = expandUses uses name
   return $ case name' of
-    "U32" -> U32
+    "U64" -> U64
     "F64" -> F64
     "Set" -> Set
     "_"   -> Met 0 []
@@ -934,7 +934,7 @@ parseSwiInl = withSrc $ do
                 buildIfChain [] = defaultBody
                 buildIfChain ((num,body):rest) = App
                   (Mat [("True", body), ("False", buildIfChain rest)])
-                  (App (App (Ref "Base/U32/eq") x) (Num (read num)))
+                  (App (App (Ref "Base/U64/eq") x) (Num (read num)))
             return $ buildIfChain nonDefaultCases
     ]
 

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -430,7 +430,7 @@ parseFloat = withSrc $ P.try $ do
   let floatStr = intPart ++ "." ++ decPart
   let value = (read floatStr :: Double) * (10 ^^ expPart)
   
-  return $ FNum value
+  return $ Flt value
 
 parseNum = withSrc $ Num . read <$> P.many1 digit
 

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -4,7 +4,7 @@ module Kind.Parse where
 
 import Data.Char (ord)
 import Data.Functor.Identity (Identity)
-import Data.List (intercalate, isPrefixOf, uncons, find)
+import Data.List (intercalate, isPrefixOf, uncons, find, transpose)
 import Data.Maybe (catMaybes, fromJust, isJust)
 import Data.Set (toList, fromList)
 import Debug.Trace
@@ -643,7 +643,7 @@ parseDefFun = do
           body <- parseTerm
           return (pats, body)
         let (mat, bods) = unzip rules
-        let flat = flattenDef mat bods 0 0
+        let flat = flattenDef mat bods 0
         return
           -- $ trace ("DONE: " ++ termShow flat)
           flat
@@ -953,62 +953,60 @@ parseNat = withSrc $ P.try $ do
 -- FIXME: the functions below are still a little bit messy and can be improved
 
 -- Flattener for pattern matching equations
-flattenDef :: [[Pattern]] -> [Term] -> Int -> Int -> Term
-flattenDef pats bods fresh depth =
+flattenDef :: [[Pattern]] -> [Term] -> Int -> Term
+flattenDef pats bods depth =
   -- trace (replicate (depth * 2) ' ' ++ "flattenDef: pats = " ++ show pats ++ ", bods = " ++ show (map termShow bods) ++ ", fresh = " ++ show fresh) $
-  go pats bods fresh depth
+  go pats bods depth
   where
-    go ([]:mat)   (bod:bods) fresh depth = bod
-    go (pats:mat) (bod:bods) fresh depth
-      | all isVar col  = flattenVarCol col mat' (bod:bods) fresh (depth + 1)
-      | otherwise      = flattenAdtCol col mat' (bod:bods) fresh (depth + 1)
+    go ([]:mat)   (bod:bods) depth = bod
+    go (pats:mat) (bod:bods) depth
+      | all isVar col  = flattenVarCol col mat' (bod:bods) (depth + 1)
+      | otherwise      = flattenAdtCol col mat' (bod:bods) (depth + 1)
       where (col,mat') = getCol (pats:mat)
-    go _ _ _ _ = error "internal error"
+    go _ _ _ = error "internal error"
 
 -- Flattens a column with only variables
-flattenVarCol :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> Int -> Term
-flattenVarCol col mat bods fresh depth =
+flattenVarCol :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> Term
+flattenVarCol col mat bods depth =
   -- trace (replicate (depth * 2) ' ' ++ "flattenVarCol: col = " ++ show col ++ ", fresh = " ++ show fresh) $
-  let nam = maybe ("%x" ++ show fresh) id (getColName col)
-      bod = flattenDef mat bods (fresh + 1) depth
+  let nam = maybe "_" id (getVarColName col)
+      bod = flattenDef mat bods depth
   in Lam nam (\x -> bod)
 
 -- Flattens a column with constructors and possibly variables
-flattenAdtCol :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> Int -> Term
-flattenAdtCol col mat bods fresh depth =
+flattenAdtCol :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> Term
+flattenAdtCol col mat bods depth =
   -- trace (replicate (depth * 2) ' ' ++ "flattenAdtCol: col = " ++ show col ++ ", fresh = " ++ show fresh) $
-  let nam = maybe ("%f" ++ show fresh) id (getColName col)
-      ctr = map (makeCtrCase col mat bods (fresh+1) nam depth) (getColCtrs col)
-      dfl = makeDflCase col mat bods fresh depth
+  let ctr = map (makeCtrCase col mat bods depth) (getColCtrs col)
+      dfl = makeDflCase col mat bods depth
   in Mat (ctr++dfl)
 
 -- Creates a constructor case: '#Name: body'
-makeCtrCase :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> String -> Int -> String -> (String, Term)
-makeCtrCase col mat bods fresh var depth ctr =
+makeCtrCase :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> String -> (String, Term)
+makeCtrCase col mat bods depth ctr =
   -- trace (replicate (depth * 2) ' ' ++ "makeCtrCase: col = " ++ show col ++ ", mat = " ++ show mat ++ ", bods = " ++ show (map termShow bods) ++ ", fresh = " ++ show fresh ++ ", var = " ++ var ++ ", ctr = " ++ ctr) $
-  let (mat', bods') = foldr go ([], []) (zip3 col mat bods)
-      bod           = flattenDef mat' bods' fresh (depth + 1)
+  let var           = getCtrColNames col ctr
+      (mat', bods') = foldr (go var) ([], []) (zip3 col mat bods)
+      bod           = flattenDef mat' bods' (depth + 1)
   in (ctr, bod)
-  where go ((PCtr nam ps), pats, bod) (mat, bods)
+  where go var ((PCtr nam ps), pats, bod) (mat, bods)
           | nam == ctr = ((ps ++ pats):mat, bod:bods)
           | otherwise  = (mat, bods)
-        go ((PVar "_"), pats, bod) (mat, bods) =
-          let ari = getCtrArity col ctr
-              pat = [PVar "_" | _ <- [0..ari-1]]
+        go var ((PVar "_"), pats, bod) (mat, bods) =
+          let pat = map (maybe (PVar "_") PVar) var
           in ((pat ++ pats):mat, bod:bods)
-        go ((PVar nam), pats, bod) (mat, bods) =
-          let ari = getCtrArity col ctr
-              var = [nam++"."++show i | i <- [0..ari-1]]
-              pat = map PVar var
-              bo2 = Let nam (foldl (\f a -> App f (Ref a)) (Ref ctr) var) (\x -> bod)
+        go var ((PVar nam), pats, bod) (mat, bods) =
+          let vr2 = [maybe (nam++"."++show i) id vr | (vr, i) <- zip var [0..]]
+              pat = map PVar vr2
+              bo2 = Use nam (Con ctr (map (\x -> (Nothing, Ref x)) vr2)) (\x -> bod)
           in ((pat ++ pats):mat, bo2:bods)
 
 -- Creates a default case: '#_: body'
-makeDflCase :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> Int -> [(String, Term)]
-makeDflCase col mat bods fresh depth =
+makeDflCase :: [Pattern] -> [[Pattern]] -> [Term] -> Int -> [(String, Term)]
+makeDflCase col mat bods depth =
   -- trace (replicate (depth * 2) ' ' ++ "makeDflCase: col = " ++ show col ++ ", fresh = " ++ show fresh) $
   let (mat', bods') = foldr go ([], []) (zip3 col mat bods) in
-  if null bods' then [] else [("_", flattenDef mat' bods' (fresh+1) (depth + 1))]
+  if null bods' then [] else [("_", flattenDef mat' bods' (depth + 1))]
   where go ((PVar nam), pats, bod) (mat, bods) = (((PVar nam):pats):mat, bod:bods)
         go (ctr,        pats, bod) (mat, bods) = (mat, bods)
 
@@ -1018,21 +1016,25 @@ isVar :: Pattern -> Bool
 isVar (PVar _) = True
 isVar _        = False
 
-getCtrArity :: [Pattern] -> String -> Int
-getCtrArity ((PCtr nam ps):pats) ctr
-  | nam == ctr           = length ps
-  | otherwise            = getCtrArity pats ctr
-getCtrArity (_:pats) ctr = getCtrArity pats ctr
-getCtrArity []        _  = 0
-
 getCol :: [[Pattern]] -> ([Pattern], [[Pattern]])
 getCol (pats:mat) = unzip (catMaybes (map uncons (pats:mat)))
 
 getColCtrs :: [Pattern] -> [String]
 getColCtrs col = toList . fromList $ foldr (\pat acc -> case pat of (PCtr nam _) -> nam:acc ; _ -> acc) [] col
 
-getColName :: [Pattern] -> Maybe String
-getColName col = foldr (A.<|>) Nothing $ map go col
+getVarColName :: [Pattern] -> Maybe String
+getVarColName col = foldr (A.<|>) Nothing $ map go col
   where go (PVar "_") = Nothing
         go (PVar nam) = Just nam
         go _          = Nothing
+
+-- For a column of patterns that will become a Mat,
+-- return the name of the inner fields or Nothing if they are also Mats.
+getCtrColNames :: [Pattern] -> String -> [Maybe String]
+getCtrColNames col ctr = 
+  let mat = foldr go [] col
+  in map getVarColName (transpose mat)
+  where go (PCtr nam ps) acc
+          | nam == ctr  = ps:acc
+          | otherwise   = acc
+        go _ acc        = acc

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -668,19 +668,35 @@ parseDef = P.choice
 parsePattern :: Parser Pattern
 parsePattern = do
   P.choice [
-    do
-      name <- name_skp
-      return (PVar name),
-    do
-      char_skp '#'
-      name <- name_skp
-      args <- P.option [] $ P.try $ do
-        char_skp '{'
-        args <- P.many parsePattern
-        char_skp '}'
-        return args
-      return (PCtr name args)
-    ]
+    parsePatternNat,
+    parsePatternCtr,
+    parsePatternVar
+    ] <* skip
+
+parsePatternNat :: Parser Pattern
+parsePatternNat = do
+  num <- P.try $ do
+    char_skp '#'
+    P.many1 digit
+  let n = read num
+  return $ (foldr (\_ acc -> PCtr "Succ" [acc]) (PCtr "Zero" []) [1..n])
+
+parsePatternCtr :: Parser Pattern
+parsePatternCtr = do
+  name <- P.try $ do
+    char_skp '#'
+    name_skp
+  args <- P.option [] $ P.try $ do
+    char_skp '{'
+    args <- P.many parsePattern
+    char_skp '}'
+    return args
+  return $ (PCtr name args)
+
+parsePatternVar :: Parser Pattern
+parsePatternVar = do
+  name <- P.try $ name_skp
+  return $ (PVar name)
 
 parseUses :: Parser Uses
 parseUses = P.many $ P.try $ do

--- a/src/Kind/Reduce.hs
+++ b/src/Kind/Reduce.hs
@@ -4,6 +4,7 @@ module Kind.Reduce where
 
 import Prelude hiding (EQ, LT, GT)
 import Data.Bits ( (.&.), (.|.), xor, shiftL, shiftR )
+import Data.Fixed (mod')
 import Data.Char (ord)
 import Debug.Trace
 import Kind.Show
@@ -89,7 +90,7 @@ reduce book fill lv term = red term where
   op2 SUB (Flt fst) (Flt snd) = Flt (fst - snd)
   op2 MUL (Flt fst) (Flt snd) = Flt (fst * snd)
   op2 DIV (Flt fst) (Flt snd) = Flt (fst / snd)
-  op2 MOD (Flt fst) (Flt snd) = error "Modulo is not supported for floating point numbers."
+  op2 MOD (Flt fst) (Flt snd) = Flt (mod' fst snd)
   op2 EQ  (Flt fst) (Flt snd) = Num (if fst == snd then 1 else 0)
   op2 NE  (Flt fst) (Flt snd) = Num (if fst /= snd then 1 else 0)
   op2 LT  (Flt fst) (Flt snd) = Num (if fst < snd then 1 else 0)

--- a/src/Kind/Reduce.hs
+++ b/src/Kind/Reduce.hs
@@ -99,10 +99,7 @@ reduce book fill lv term = red term where
   op2 AND (FNum _) (FNum _) = error "Bitwise AND not supported for floating-point numbers"
   op2 OR  (FNum _) (FNum _) = error "Bitwise OR not supported for floating-point numbers"
   op2 XOR (FNum _) (FNum _) = error "Bitwise XOR not supported for floating-point numbers"
-
   op2 opr fst       snd       = Op2 opr fst snd
-  
-
 
   ref nam | lv > 0 = case M.lookup nam book of
     Just val -> red val

--- a/src/Kind/Reduce.hs
+++ b/src/Kind/Reduce.hs
@@ -83,7 +83,7 @@ reduce book fill lv term = red term where
   op2 LSH (Num fst) (Num snd) = Num (shiftL fst (fromIntegral snd))
   op2 RSH (Num fst) (Num snd) = Num (shiftR fst (fromIntegral snd))
 
-  op2 op  (Ref nam)  (Flt snd) | lv > 0 = op2 op (ref nam) (Flt snd)
+  op2 op  (Ref nam) (Flt snd)  | lv > 0 = op2 op (ref nam) (Flt snd)
   op2 op  (Flt fst) (Ref nam)  | lv > 0 = op2 op (Flt fst) (ref nam)
   op2 ADD (Flt fst) (Flt snd) = Flt (fst + snd)
   op2 SUB (Flt fst) (Flt snd) = Flt (fst - snd)
@@ -96,9 +96,9 @@ reduce book fill lv term = red term where
   op2 GT  (Flt fst) (Flt snd) = Num (if fst > snd then 1 else 0)
   op2 LTE (Flt fst) (Flt snd) = Num (if fst <= snd then 1 else 0)
   op2 GTE (Flt fst) (Flt snd) = Num (if fst >= snd then 1 else 0)
-  op2 AND (Flt _) (Flt _) = error "Bitwise AND not supported for floating-point numbers"
-  op2 OR  (Flt _) (Flt _) = error "Bitwise OR not supported for floating-point numbers"
-  op2 XOR (Flt _) (Flt _) = error "Bitwise XOR not supported for floating-point numbers"
+  op2 AND (Flt _)   (Flt _)   = error "Bitwise AND not supported for floating-point numbers"
+  op2 OR  (Flt _)   (Flt _)   = error "Bitwise OR not supported for floating-point numbers"
+  op2 XOR (Flt _)   (Flt _)   = error "Bitwise XOR not supported for floating-point numbers"
   op2 opr fst       snd       = Op2 opr fst snd
 
   ref nam | lv > 0 = case M.lookup nam book of

--- a/src/Kind/Reduce.hs
+++ b/src/Kind/Reduce.hs
@@ -187,7 +187,7 @@ normal book fill lv term dep = go (reduce book fill lv term) dep where
     Use nam nf_val nf_bod
   go (Hol nam ctx) dep = Hol nam ctx
   go Set dep = Set
-  go U32 dep = U32
+  go U64 dep = U64
   go F64 dep = F64
   go (Num val) dep = Num val
   go (Flt val) dep = Flt val
@@ -279,7 +279,7 @@ bind (Use nam val bod) ctx =
   let bod' = \x -> bind (bod (Var nam 0)) ((nam, x) : ctx) in
   Use nam val' bod'
 bind Set ctx = Set
-bind U32 ctx = U32
+bind U64 ctx = U64
 bind F64 ctx = F64
 bind (Num val) ctx = Num val
 bind (Flt val) ctx = Flt val

--- a/src/Kind/Reduce.hs
+++ b/src/Kind/Reduce.hs
@@ -83,22 +83,22 @@ reduce book fill lv term = red term where
   op2 LSH (Num fst) (Num snd) = Num (shiftL fst (fromIntegral snd))
   op2 RSH (Num fst) (Num snd) = Num (shiftR fst (fromIntegral snd))
 
-  op2 op  (Ref nam)  (FNum snd) | lv > 0 = op2 op (ref nam) (FNum snd)
-  op2 op  (FNum fst) (Ref nam)  | lv > 0 = op2 op (FNum fst) (ref nam)
-  op2 ADD (FNum fst) (FNum snd) = FNum (fst + snd)
-  op2 SUB (FNum fst) (FNum snd) = FNum (fst - snd)
-  op2 MUL (FNum fst) (FNum snd) = FNum (fst * snd)
-  op2 DIV (FNum fst) (FNum snd) = FNum (fst / snd)
-  op2 MOD (FNum fst) (FNum snd) = error "Modulo is not supported for floating point numbers."
-  op2 EQ  (FNum fst) (FNum snd) = Num (if fst == snd then 1 else 0)
-  op2 NE  (FNum fst) (FNum snd) = Num (if fst /= snd then 1 else 0)
-  op2 LT  (FNum fst) (FNum snd) = Num (if fst < snd then 1 else 0)
-  op2 GT  (FNum fst) (FNum snd) = Num (if fst > snd then 1 else 0)
-  op2 LTE (FNum fst) (FNum snd) = Num (if fst <= snd then 1 else 0)
-  op2 GTE (FNum fst) (FNum snd) = Num (if fst >= snd then 1 else 0)
-  op2 AND (FNum _) (FNum _) = error "Bitwise AND not supported for floating-point numbers"
-  op2 OR  (FNum _) (FNum _) = error "Bitwise OR not supported for floating-point numbers"
-  op2 XOR (FNum _) (FNum _) = error "Bitwise XOR not supported for floating-point numbers"
+  op2 op  (Ref nam)  (Flt snd) | lv > 0 = op2 op (ref nam) (Flt snd)
+  op2 op  (Flt fst) (Ref nam)  | lv > 0 = op2 op (Flt fst) (ref nam)
+  op2 ADD (Flt fst) (Flt snd) = Flt (fst + snd)
+  op2 SUB (Flt fst) (Flt snd) = Flt (fst - snd)
+  op2 MUL (Flt fst) (Flt snd) = Flt (fst * snd)
+  op2 DIV (Flt fst) (Flt snd) = Flt (fst / snd)
+  op2 MOD (Flt fst) (Flt snd) = error "Modulo is not supported for floating point numbers."
+  op2 EQ  (Flt fst) (Flt snd) = Num (if fst == snd then 1 else 0)
+  op2 NE  (Flt fst) (Flt snd) = Num (if fst /= snd then 1 else 0)
+  op2 LT  (Flt fst) (Flt snd) = Num (if fst < snd then 1 else 0)
+  op2 GT  (Flt fst) (Flt snd) = Num (if fst > snd then 1 else 0)
+  op2 LTE (Flt fst) (Flt snd) = Num (if fst <= snd then 1 else 0)
+  op2 GTE (Flt fst) (Flt snd) = Num (if fst >= snd then 1 else 0)
+  op2 AND (Flt _) (Flt _) = error "Bitwise AND not supported for floating-point numbers"
+  op2 OR  (Flt _) (Flt _) = error "Bitwise OR not supported for floating-point numbers"
+  op2 XOR (Flt _) (Flt _) = error "Bitwise XOR not supported for floating-point numbers"
   op2 opr fst       snd       = Op2 opr fst snd
 
   ref nam | lv > 0 = case M.lookup nam book of
@@ -189,7 +189,7 @@ normal book fill lv term dep = go (reduce book fill lv term) dep where
   go U32 dep = U32
   go F64 dep = F64
   go (Num val) dep = Num val
-  go (FNum val) dep = FNum val
+  go (Flt val) dep = Flt val
   go (Op2 opr fst snd) dep =
     let nf_fst = normal book fill lv fst dep in
     let nf_snd = normal book fill lv snd dep in
@@ -281,7 +281,7 @@ bind Set ctx = Set
 bind U32 ctx = U32
 bind F64 ctx = F64
 bind (Num val) ctx = Num val
-bind (FNum val) ctx = FNum val
+bind (Flt val) ctx = Flt val
 bind (Op2 opr fst snd) ctx =
   let fst' = bind fst ctx in
   let snd' = bind snd ctx in

--- a/src/Kind/Show.hs
+++ b/src/Kind/Show.hs
@@ -80,7 +80,7 @@ termShower small term dep =
             bod' = termShower small (bod (Var nam dep)) (dep + 1)
         in concat ["use " , nam' , " = " , val' , " " , bod']
       Set -> "*"
-      U32 -> "U32"
+      U64 -> "U64"
       F64 -> "F64"
       Num val ->
         let val' = show val

--- a/src/Kind/Show.hs
+++ b/src/Kind/Show.hs
@@ -85,7 +85,7 @@ termShower small term dep =
       Num val ->
         let val' = show val
         in concat [val']
-      FNum val ->
+      Flt val ->
         let val' = show val
         in concat [val']
       Op2 opr fst snd ->

--- a/src/Kind/Show.hs
+++ b/src/Kind/Show.hs
@@ -81,7 +81,11 @@ termShower small term dep =
         in concat ["use " , nam' , " = " , val' , " " , bod']
       Set -> "*"
       U32 -> "U32"
+      F64 -> "F64"
       Num val ->
+        let val' = show val
+        in concat [val']
+      FNum val ->
         let val' = show val
         in concat [val']
       Op2 opr fst snd ->

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -4,7 +4,7 @@ import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Strict as M
 
 import Debug.Trace
-import Data.Word (Word32)
+import Data.Word (Word64)
 
 -- Kind's AST
 data Term
@@ -47,11 +47,11 @@ data Term
   -- Type : Type
   | Set
 
-  -- U32 Type
-  | U32
+  -- U64 Type
+  | U64
 
-  -- U32 Value
-  | Num Word32
+  -- U64 Value
+  | Num Word64
 
   -- F64 Type
   | F64
@@ -62,7 +62,7 @@ data Term
   -- Binary Operation
   | Op2 Oper Term Term
 
-  -- U32 Elimination (updated to use splitting lambda)
+  -- U64 Elimination (updated to use splitting lambda)
   | Swi Term Term
 
   -- Inspection Hole

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -53,7 +53,13 @@ data Term
   -- U32 Value
   | Num Word32
 
-  -- U32 Binary Operation
+  -- F64 Type
+  | F64
+
+  -- F64 value
+  | FNum Double
+
+  -- Binary Operation
   | Op2 Oper Term Term
 
   -- U32 Elimination (updated to use splitting lambda)

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -57,7 +57,7 @@ data Term
   | F64
 
   -- F64 value
-  | FNum Double
+  | Flt Double
 
   -- Binary Operation
   | Op2 Oper Term Term

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -33,7 +33,7 @@ getDeps term = case term of
   U32           -> []
   F64           -> []
   Num _         -> []
-  FNum _        -> []
+  Flt _        -> []
   Txt _         -> []
   Lst elems     -> concatMap getDeps elems
   Nat _         -> []

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -33,7 +33,7 @@ getDeps term = case term of
   U32           -> []
   F64           -> []
   Num _         -> []
-  Flt _        -> []
+  Flt _         -> []
   Txt _         -> []
   Lst elems     -> concatMap getDeps elems
   Nat _         -> []

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -31,7 +31,9 @@ getDeps term = case term of
   Var _ _       -> []
   Set           -> []
   U32           -> []
+  F64           -> []
   Num _         -> []
+  FNum _        -> []
   Txt _         -> []
   Lst elems     -> concatMap getDeps elems
   Nat _         -> []

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -30,7 +30,7 @@ getDeps term = case term of
   Log msg nxt   -> getDeps msg ++ getDeps nxt
   Var _ _       -> []
   Set           -> []
-  U32           -> []
+  U64           -> []
   F64           -> []
   Num _         -> []
   Flt _         -> []


### PR DESCRIPTION
Adding support to F64 literals and operators. Below there is an example of the use of floats:
```
main : F64
= (+ 1.0 1.0)
```

@VictorTaelin I have doubts about error reporting in the operator case. 
For example, consider the following:
```
a : String
a = ""

main : F64
= (+ a a)
```
This will report error as the print below:
![image](https://github.com/user-attachments/assets/47135d15-9977-47bf-9ee2-5489206eeabf)
But this is not really clear and kinda ugly, so i wanted to know the preferences. Also, in the following case:

```
main : F64
= (+ 1 1.0)
```

It will report as:
![image](https://github.com/user-attachments/assets/c0aff219-cb99-4fbb-a5a4-959120a41904)

Because it checks that the first operator type should be the same as the second, and then it checks that the reduction is of the type of main.