### PR TITLE
Use the term from 'check' to check for unfilled metas

### DIFF
--- a/src/Kind/API.hs
+++ b/src/Kind/API.hs
@@ -93,9 +93,9 @@ apiCheck bookPath (book, defs, _) defName defPath = do
         case M.lookup fileDefName book of
           Just term -> do
             case envRun (doCheck term) book of
-              Done state _ -> do
+              Done state chkTerm -> do
                 apiPrintLogs state
-                apiPrintWarn term state
+                apiPrintWarn chkTerm state
                 putStrLn $ "\x1b[32m✓ " ++ fileDefName ++ "\x1b[0m"
                 return $ Right ()
               Fail state -> do

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -361,7 +361,7 @@ checkUnreachable src cNam term dep = go src cNam term dep where
 
 checkLater :: Bool -> Maybe Cod -> Term -> Term -> Int -> Env Term
 checkLater False src term typx dep = check False src term typx dep
-checkLater True  src term typx dep = envSusp (Check src term typx dep) >> return (Met 0 [])
+checkLater True  src term typx dep = envSusp (Check src term typx dep) >> return term
 
 doCheckMode :: Bool -> Term -> Env Term
 doCheckMode sus (Ann _ val typ) = do


### PR DESCRIPTION
Changes doCheck to return the term resulting from the check. Also changes checkLater to not insert Met terms when delaying checking.

By checking for unfilled metas on the term after the check (after discarding redundant match cases), we don't get "unfilled metas" warning on redundant match cases anymore.