### PR TITLE
Op2 checking + I64

### DIFF
--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -80,6 +80,9 @@ infer sus src term dep = debug ("infer:" ++ (if sus then "* " else " ") ++ showT
   go U64 = do
     return $ Ann False U64 Set
 
+  go I64 = do
+    return $ Ann False I64 Set
+
   go F64 = do
     return $ Ann False F64 Set
 
@@ -88,6 +91,9 @@ infer sus src term dep = debug ("infer:" ++ (if sus then "* " else " ") ++ showT
 
   go (Flt num) = do
     return $ Ann False (Flt num) F64
+
+  go (Int num) = do
+    return $ Ann False (Int num) I64
 
   go (Op2 opr fst snd) = do
     envLog (Error src (Ref "annotation") (Ref "Op2") (Op2 opr fst snd) dep)

--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -98,6 +98,10 @@ infer sus src term dep = debug ("infer:" ++ (if sus then "* " else " ") ++ showT
   go (Op2 opr fst snd) = do
     envLog (Error src (Ref "annotation") (Ref "Op2") (Op2 opr fst snd) dep)
     envFail
+  
+  go (Op1 opr fst) = do
+    envLog (Error src (Ref "annotation") (Ref "Op1") (Op1 opr fst) dep)
+    envFail
 
   go (Swi zer suc) = do
     envLog (Error src (Ref "annotation") (Ref "switch") (Swi zer suc) dep)
@@ -296,6 +300,20 @@ check sus src term typx dep = debug ("check:" ++ (if sus then "* " else " ") ++ 
       let returnType = getOpReturnType opr reducedFst reducedSnd
 
       return $ Ann False (Op2 opr fst snd) returnType
+
+  go (Op1 opr fst) = do
+    fstT <- infer sus src fst dep
+
+    t1 <- equal (getType fstT) typx dep
+    if not t1 then do
+      envLog (Error src typx (getType fstT) (Op1 opr fst) dep)
+      envFail
+    else do
+      book <- envGetBook
+      fill <- envGetFill
+      let reducedFst = reduce book fill 1 (getType fstT)
+      let returnType = getOp1ReturnType opr reducedFst
+      return $ Ann False (Op1 opr fst) returnType
 
   go (Swi zer suc) = do
     book <- envGetBook

--- a/src/Kind/Equal.hs
+++ b/src/Kind/Equal.hs
@@ -114,9 +114,13 @@ identical a b dep = do
     return True
   go F64 F64 dep =
     return True
+  go I64 I64 dep =
+    return True
   go (Num aVal) (Num bVal) dep =
     return (aVal == bVal)
   go (Flt aVal) (Flt bVal) dep =
+    return (aVal == bVal)
+  go (Int aVal) (Int bVal) dep =
     return (aVal == bVal)
   go (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep = do
     iFst <- identical aFst bFst dep
@@ -407,9 +411,13 @@ same U64 U64 dep =
   True
 same F64 F64 dep =
   True
+same I64 I64 dep =
+  True
 same (Num aVal) (Num bVal) dep =
   aVal == bVal
 same (Flt aVal) (Flt bVal) dep =
+  aVal == bVal
+same (Int aVal) (Int bVal) dep =
   aVal == bVal
 same (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep =
   same aFst bFst dep && same aSnd bSnd dep
@@ -474,8 +482,10 @@ subst lvl neo term = go term where
   go Set               = Set
   go U64               = U64
   go F64               = F64
+  go I64               = I64
   go (Num n)           = Num n
   go (Flt n)           = Flt n
+  go (Int n)           = Int n
   go (Op2 opr fst snd) = Op2 opr (go fst) (go snd)
   go (Txt txt)         = Txt txt
   go (Lst lst)         = Lst (map go lst)
@@ -508,8 +518,10 @@ replace old neo term dep = if same old term dep then neo else go term where
   go (Hol nam ctx)      = Hol nam (map (\x -> replace old neo x (dep+1)) ctx)
   go Set                = Set
   go U64                = U64
+  go I64                = I64
   go F64                = F64
   go (Num n)            = Num n
+  go (Int n)            = Int n
   go (Flt n)            = Flt n
   go (Op2 opr fst snd)  = Op2 opr (replace old neo fst dep) (replace old neo snd dep)
   go (Txt txt)          = Txt txt

--- a/src/Kind/Equal.hs
+++ b/src/Kind/Equal.hs
@@ -126,6 +126,9 @@ identical a b dep = do
     iFst <- identical aFst bFst dep
     iSnd <- identical aSnd bSnd dep
     return (iFst && iSnd)
+  go (Op1 aOpr aFst) (Op1 bOpr bFst) dep = do
+    iFst <- identical aFst bFst dep
+    return iFst
   go (Swi aZer aSuc) (Swi bZer bSuc) dep = do
     iZer <- identical aZer bZer dep
     iSuc <- identical aSuc bSuc dep
@@ -202,6 +205,9 @@ similar a b dep = go a b dep where
     eFst <- equal aFst bFst dep
     eSnd <- equal aSnd bSnd dep
     return (eFst && eSnd)
+  go (Op1 aOpr aFst) (Op1 bOpr bFst) dep = do
+    eFst <- equal aFst bFst dep
+    return eFst
   go (Swi aZer aSuc) (Swi bZer bSuc) dep = do
     eZer <- equal aZer bZer dep
     eSuc <- equal aSuc bSuc dep
@@ -322,6 +328,9 @@ occur book fill uid term dep = go term dep where
     let o_fst = go fst dep
         o_snd = go snd dep
     in o_fst || o_snd
+  go (Op1 opr fst) dep =
+    let o_fst = go fst dep
+    in o_fst
   go (Swi zer suc) dep =
     let o_zer = go zer dep
         o_suc = go suc dep
@@ -421,6 +430,8 @@ same (Int aVal) (Int bVal) dep =
   aVal == bVal
 same (Op2 aOpr aFst aSnd) (Op2 bOpr bFst bSnd) dep =
   same aFst bFst dep && same aSnd bSnd dep
+same (Op1 aOpr aFst) (Op1 bOpr bFst) dep =
+  same aFst bFst dep
 same (Swi aZer aSuc) (Swi bZer bSuc) dep =
   same aZer bZer dep && same aSuc bSuc dep
 same (Txt aTxt) (Txt bTxt) dep =
@@ -487,6 +498,7 @@ subst lvl neo term = go term where
   go (Flt n)           = Flt n
   go (Int n)           = Int n
   go (Op2 opr fst snd) = Op2 opr (go fst) (go snd)
+  go (Op1 opr fst)     = Op1 opr (go fst)
   go (Txt txt)         = Txt txt
   go (Lst lst)         = Lst (map go lst)
   go (Nat val)         = Nat val
@@ -524,6 +536,7 @@ replace old neo term dep = if same old term dep then neo else go term where
   go (Int n)            = Int n
   go (Flt n)            = Flt n
   go (Op2 opr fst snd)  = Op2 opr (replace old neo fst dep) (replace old neo snd dep)
+  go (Op1 opr fst)      = Op1 opr (replace old neo fst dep)
   go (Txt txt)          = Txt txt
   go (Lst lst)          = Lst (map (\x -> replace old neo x dep) lst)
   go (Nat val)          = Nat val

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -214,7 +214,7 @@ parseApp = withSrc $ do
   fun <- parseTerm
   args <- P.many $ do
     P.notFollowedBy (char_end ')')
-    era <- P.optionMaybe (char_skp '-')
+    era <- P.optionMaybe (char_skp '~')
     arg <- parseTerm
     return (era, arg)
   char_end ')'

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -155,6 +155,7 @@ parseTerm = (do
     , parseMat
     , parseLam
     , parseEra
+    , parseOp1
     , parseOp2
     , parseApp
     , parseAnn
@@ -451,6 +452,14 @@ parseOp2 = withSrc $ do
   char_end ')'
   return $ Op2 opr fst snd
 
+parseOp1 = withSrc $ do
+  opr <- P.try $ do
+    char_skp '('
+    parseOper1
+  fst <- parseTerm
+  char_end ')'
+  return $ Op1 opr fst
+
 parseLst = withSrc $ do
   char_skp '['
   elems <- P.many parseTerm
@@ -525,6 +534,12 @@ parseOper = P.choice
   , P.try (string_skp "&") >> return AND
   , P.try (string_skp "|") >> return OR
   , P.try (string_skp "^") >> return XOR
+  ]
+
+parseOper1 = P.choice
+  [ P.try (string_skp "cos") >> return COS
+  , P.try (string_skp "sin") >> return SIN
+  , P.try (string_skp "tan") >> return TAN
   ]
 
 parseSuffix :: Term -> Parser Term

--- a/src/Kind/Reduce.hs
+++ b/src/Kind/Reduce.hs
@@ -99,6 +99,19 @@ reduce book fill lv term = red term where
   op2 AND (Flt _)   (Flt _)   = error "Bitwise AND not supported for floating-point numbers"
   op2 OR  (Flt _)   (Flt _)   = error "Bitwise OR not supported for floating-point numbers"
   op2 XOR (Flt _)   (Flt _)   = error "Bitwise XOR not supported for floating-point numbers"
+  op2 op  (Ref nam) (Int snd) | lv > 0 = op2 op (ref nam) (Int snd)
+  op2 op  (Int fst) (Ref nam) | lv > 0 = op2 op (Int fst) (ref nam)
+  op2 ADD (Int fst) (Int snd) = Int (fst + snd)
+  op2 SUB (Int fst) (Int snd) = Int (fst - snd)
+  op2 MUL (Int fst) (Int snd) = Int (fst * snd)
+  op2 DIV (Int fst) (Int snd) = Int (div fst snd)
+  op2 MOD (Int fst) (Int snd) = Int (mod fst snd)
+  op2 EQ  (Int fst) (Int snd) = Num (if fst == snd then 1 else 0)
+  op2 NE  (Int fst) (Int snd) = Num (if fst /= snd then 1 else 0)
+  op2 LT  (Int fst) (Int snd) = Num (if fst < snd then 1 else 0)
+  op2 GT  (Int fst) (Int snd) = Num (if fst > snd then 1 else 0)
+  op2 LTE (Int fst) (Int snd) = Num (if fst <= snd then 1 else 0)
+  op2 GTE (Int fst) (Int snd) = Num (if fst >= snd then 1 else 0)
   op2 opr fst       snd       = Op2 opr fst snd
 
   ref nam | lv > 0 = case M.lookup nam book of
@@ -188,8 +201,10 @@ normal book fill lv term dep = go (reduce book fill lv term) dep where
   go Set dep = Set
   go U64 dep = U64
   go F64 dep = F64
+  go I64 dep = I64
   go (Num val) dep = Num val
   go (Flt val) dep = Flt val
+  go (Int val) dep = Int val
   go (Op2 opr fst snd) dep =
     let nf_fst = normal book fill lv fst dep in
     let nf_snd = normal book fill lv snd dep in
@@ -280,8 +295,10 @@ bind (Use nam val bod) ctx =
 bind Set ctx = Set
 bind U64 ctx = U64
 bind F64 ctx = F64
+bind I64 ctx = I64
 bind (Num val) ctx = Num val
 bind (Flt val) ctx = Flt val
+bind (Int val) ctx = Int val
 bind (Op2 opr fst snd) ctx =
   let fst' = bind fst ctx in
   let snd' = bind snd ctx in

--- a/src/Kind/Show.hs
+++ b/src/Kind/Show.hs
@@ -83,11 +83,15 @@ showTermGo small term dep =
         in concat ["use " , nam' , " = " , val' , " " , bod']
       Set -> "*"
       U64 -> "U64"
+      I64 -> "I64"
       F64 -> "F64"
       Num val ->
         let val' = show val
         in concat [val']
       Flt val ->
+        let val' = show val
+        in concat [val']
+      Int val ->
         let val' = show val
         in concat [val']
       Op2 opr fst snd ->

--- a/src/Kind/Show.hs
+++ b/src/Kind/Show.hs
@@ -94,6 +94,10 @@ showTermGo small term dep =
       Int val ->
         let val' = show val
         in concat [val']
+      Op1 opr fst ->
+        let opr' = showOper1 opr
+            fst' = showTermGo small fst dep
+        in concat ["(" , opr' , " ", fst', ")"]
       Op2 opr fst snd ->
         let opr' = showOper opr
             fst' = showTermGo small fst dep
@@ -156,6 +160,11 @@ showOper OR  = "|"
 showOper XOR = "^"
 showOper LSH = "<<"
 showOper RSH = ">>"
+
+showOper1 :: Oper1 -> String
+showOper1 COS = "cos"
+showOper1 SIN = "sin"
+showOper1 TAN = "tan"
 
 -- Pretty Printing (Sugars)
 -- ------------------------

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -105,6 +105,7 @@ data Cod = Cod Loc Loc
 
 data Oper1
   = COS | SIN | TAN
+  deriving Show
 
 -- Numeric Operators
 data Oper 

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -69,6 +69,9 @@ data Term
   -- Binary Operation
   | Op2 Oper Term Term
 
+  -- Unary Operation
+  | Op1 Oper1 Term
+
   -- U64 Elimination (updated to use splitting lambda)
   | Swi Term Term
 
@@ -99,6 +102,9 @@ data Term
 -- Location: Name, Line, Column
 data Loc = Loc String Int Int
 data Cod = Cod Loc Loc
+
+data Oper1
+  = COS | SIN | TAN
 
 -- Numeric Operators
 data Oper 

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -5,6 +5,7 @@ import qualified Data.Map.Strict as M
 
 import Debug.Trace
 import Data.Word (Word64)
+import Data.Int (Int64)
 
 -- Kind's AST
 data Term
@@ -53,11 +54,17 @@ data Term
   -- F64 Type
   | F64
 
+  -- I64 Type
+  | I64
+
   -- U64 Value
   | Num Word64
 
   -- F64 Value
   | Flt Double
+
+  -- I64 Value
+  | Int Int64
 
   -- Binary Operation
   | Op2 Oper Term Term

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -29,6 +29,7 @@ getDeps term = case term of
   Let _ val bod -> getDeps val ++ getDeps (bod Set)
   Use _ val bod -> getDeps val ++ getDeps (bod Set)
   Op2 _ fst snd -> getDeps fst ++ getDeps snd
+  Op1 _ fst     -> getDeps fst 
   Swi zer suc   -> getDeps zer ++ getDeps suc
   Src _ val     -> getDeps val
   Hol _ args    -> concatMap getDeps args
@@ -185,5 +186,12 @@ getOpReturnType OR  U64 _    = U64
 getOpReturnType XOR U64 _    = U64
 getOpReturnType LSH U64 _    = U64
 getOpReturnType RSH U64 _    = U64
-getOpReturnType opr trm1 trm2 = error ("Invalid operator: " ++ (show opr) ++ " Invalid operand types: " ++ (showTerm trm1) ++ ", " ++ (showTerm trm2))
+getOpReturnType opr t1  t2   = error ("Invalid operator: " ++ (show opr) ++ " Invalid operand types: " ++ (showTerm t1) ++ ", " ++ (showTerm t2))
+
+
+getOp1ReturnType :: Oper1 -> Term -> Term
+getOp1ReturnType COS F64 = F64
+getOp1ReturnType SIN F64 = F64
+getOp1ReturnType TAN F64 = F64
+getOp1ReturnType opr t   = error ("Invalid operator: " ++ (show opr) ++ " Invalid operand type: " ++ (showTerm t))
 

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -144,32 +144,35 @@ getForallNames (All nam _ bod) = nam : getForallNames (bod Set)
 getForallNames (Src _ val)     = getForallNames val
 getForallNames _               = []
 
-getOpReturnType :: Oper -> Term -> Term
-getOpReturnType ADD U64 = U64
-getOpReturnType ADD F64 = F64
-getOpReturnType SUB U64 = U64
-getOpReturnType SUB F64 = F64
-getOpReturnType MUL U64 = U64
-getOpReturnType MUL F64 = F64
-getOpReturnType DIV U64 = U64
-getOpReturnType DIV F64 = F64
-getOpReturnType MOD U64 = U64
-getOpReturnType EQ  _   = U64
-getOpReturnType NE  _   = U64
-getOpReturnType LT  _   = U64
-getOpReturnType GT  _   = U64
-getOpReturnType LTE _   = U64
-getOpReturnType GTE _   = U64
-getOpReturnType AND U64 = U64
-getOpReturnType OR  U64 = U64
-getOpReturnType XOR U64 = U64
-getOpReturnType LSH U64 = U64
-getOpReturnType RSH U64 = U64
-getOpReturnType opr trm = error ("Invalid opertor: " ++ (show opr) ++ " Invalid operand type: " ++ (showTerm trm))
-
-checkValidType :: Term -> [Term] -> Int -> Env Bool
-checkValidType typ validTypes dep = foldr (\t acc -> do
-    isEqual <- equal typ t dep
-    if isEqual then return True else acc
-  ) (return False) validTypes
+-- Returns the type of a numeric operation given its operands.
+getOpReturnType :: Oper -> Term -> Term -> Term
+getOpReturnType ADD U64 _    = U64
+getOpReturnType ADD F64 _    = F64
+getOpReturnType ADD _   U64  = U64
+getOpReturnType ADD _   F64  = F64
+getOpReturnType SUB U64 _    = U64
+getOpReturnType SUB F64 _    = F64
+getOpReturnType SUB _   U64  = U64
+getOpReturnType SUB _   F64  = F64
+getOpReturnType MUL U64 _    = U64
+getOpReturnType MUL F64 _    = F64
+getOpReturnType MUL _   U64  = U64
+getOpReturnType MUL _   F64  = F64
+getOpReturnType DIV U64 _    = U64
+getOpReturnType DIV F64 _    = F64
+getOpReturnType DIV _   U64  = U64
+getOpReturnType DIV _   F64  = F64
+getOpReturnType MOD U64 _    = U64
+getOpReturnType EQ  _   _    = U64
+getOpReturnType NE  _   _    = U64
+getOpReturnType LT  _   _    = U64
+getOpReturnType GT  _   _    = U64
+getOpReturnType LTE _   _    = U64
+getOpReturnType GTE _   _    = U64
+getOpReturnType AND U64 _    = U64
+getOpReturnType OR  U64 _    = U64
+getOpReturnType XOR U64 _    = U64
+getOpReturnType LSH U64 _    = U64
+getOpReturnType RSH U64 _    = U64
+getOpReturnType opr trm1 trm2 = error ("Invalid operator: " ++ (show opr) ++ " Invalid operand types: " ++ (showTerm trm1) ++ ", " ++ (showTerm trm2))
 

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -38,8 +38,10 @@ getDeps term = case term of
   Set           -> []
   U64           -> []
   F64           -> []
+  I64           -> []
   Num _         -> []
   Flt _         -> []
+  Int _         -> []
   Txt _         -> []
   Lst elems     -> concatMap getDeps elems
   Nat _         -> []
@@ -148,21 +150,30 @@ getForallNames _               = []
 getOpReturnType :: Oper -> Term -> Term -> Term
 getOpReturnType ADD U64 _    = U64
 getOpReturnType ADD F64 _    = F64
+getOpReturnType ADD I64 _    = I64
 getOpReturnType ADD _   U64  = U64
 getOpReturnType ADD _   F64  = F64
+getOpReturnType ADD _   I64  = F64
 getOpReturnType SUB U64 _    = U64
 getOpReturnType SUB F64 _    = F64
+getOpReturnType SUB I64 _    = I64
 getOpReturnType SUB _   U64  = U64
 getOpReturnType SUB _   F64  = F64
+getOpReturnType SUB _   I64  = I64
 getOpReturnType MUL U64 _    = U64
 getOpReturnType MUL F64 _    = F64
+getOpReturnType MUL I64 _    = I64
 getOpReturnType MUL _   U64  = U64
 getOpReturnType MUL _   F64  = F64
+getOpReturnType MUL _   I64  = I64
 getOpReturnType DIV U64 _    = U64
 getOpReturnType DIV F64 _    = F64
+getOpReturnType DIV I64 _    = I64
 getOpReturnType DIV _   U64  = U64
 getOpReturnType DIV _   F64  = F64
+getOpReturnType DIV _   I64  = I64
 getOpReturnType MOD U64 _    = U64
+getOpReturnType MOD I64 _    = I64
 getOpReturnType EQ  _   _    = U64
 getOpReturnType NE  _   _    = U64
 getOpReturnType LT  _   _    = U64


### PR DESCRIPTION
This adds `I64` type and fixes Op2 type checking.

Note: need to fix the era inside app parsing so that we can write:
```
main : I64 
= (+ -1 -1)
```
otherwise it parses the - as era notation